### PR TITLE
Add popular language styles and basic MCP support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,7 +43,7 @@ It adds two numbers. For example, `calculator.add(2, 2) // returns 4`
 2. Pick the file you want to put the reference in.
 3. Pick a place to put the comment. Ideally, the comment is right next to the implementation. The second best place is the top of the file, but this is not preferred. Try to limit the scope as much as possible.
 4. Using the commenting rules of the file, add a comment with the format: `spec(<filename>.<id>)` or `spec(<filename>.<id>): Optional body.`.
-5. Check that the spec is returned by running the `scan` command. If it still doesn't show, it's possible that the file type is not supported. Inform the user to create an issue at https://github.com/stringsync/spec.
+5. Check that the spec is returned by running the `scan` command. If it still doesn't show, it's possible that there is a bug in @stringsync/spec. Inform the user to create an issue at https://github.com/stringsync/spec.
 
 <good-example>
 
@@ -66,7 +66,7 @@ class Calculator {
 
 <bad-example>
 
-This is a bad example because the tag is at the top of the file, when a more specific place is available.
+This is a bad example because the tag is at the top of the file, when a more specific place makes sense.
 
 ```ts
 // spec(calculator.add)
@@ -86,7 +86,7 @@ class Calculator {
 
 ## Using Specs
 
-Specs prevent you from manually scan a codebase for implementations. Therefore, you should use them to quickly know what code is relevant to the user's request.
+Specs prevent you from manually scanning a codebase for implementations. Therefore, you should use them to quickly know what code is relevant to the user's request.
 
 1. Run the `scan` command to find the specs and tags in scope.
 2. Examine the spec results and read the ones you might be interested in. Find the spec ID with the format: `<filename>.<id>`.

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ It adds two numbers.
 Check the spec.
 
 ```
-bunx @stringsync/spec check calculator.md
+bunx @stringsync/spec check calculator.spec.md
 ```
 
 Reference the spec.

--- a/README.md
+++ b/README.md
@@ -54,15 +54,37 @@ bunx @stringsync/spec
 
 ## MCP
 
-_Coming soon_
+_⚠️ Work in Progress_
 
-@stringsync/spec will have an MCP server that provides:
+To help your agent understand @stringsync/spec, instruct it to read https://raw.githubusercontent.com/stringsync/spec/refs/heads/master/AGENTS.md.
 
-- tools to check specs and scan for tags
-- prompts to implement specs
-- prompts to infer and tag specs from existing code
+To run the @stringsync/spec MCP server, the command is:
 
-For now, instruct your agent to read https://raw.githubusercontent.com/stringsync/spec/refs/heads/master/AGENTS.md.
+```sh
+bunx @stringsync/spec mcp
+```
+
+Read your agent's documentation to run the MCP server. For example, Claude's configuration will look like this:
+
+```json
+{
+  "mcpServers": {
+    "@stringsync/spec": {
+      "command": "bunx",
+      "args": ["-y", "@stringsync/spec", "mcp"]
+    }
+  }
+}
+```
+
+> [!NOTE]  
+> The `-y` flag skips confirmation to download packages.
+
+To run the MCP inspector, run:
+
+```sh
+bunx @modelcontextprotocol/inspector bunx @stringsync/spec mcp
+```
 
 ## Dev
 

--- a/actions/mcp.ts
+++ b/actions/mcp.ts
@@ -8,33 +8,13 @@ import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 import { DEFAULT_IGNORE_PATTERNS, DEFAULT_PATTERNS, scan, type ScanResult } from '~/actions/scan';
 
 export async function mcp() {
-  const server = new McpServer({
-    name,
-    version,
-  });
+  const server = new McpServer({ name, version });
 
   server.tool(
     'spec.check',
     'validate a @stringsync/spec spec file',
-    {
-      path: z.string().describe('the path to the spec file to validate'),
-    },
-    async ({ path }) => {
-      const builder = new CallToolResultBuilder();
-
-      const result = await check({ path });
-      switch (result.type) {
-        case 'success':
-          builder.text(`valid @stringsync/spec: ${path}`);
-          break;
-        case 'error':
-          builder.text(`invalid @stringsync/spec: ${path}`);
-          builder.error(new PublicError(result.errors.join('\n')));
-          break;
-      }
-
-      return builder.build();
-    },
+    { path: z.string().describe('the path to the spec file to validate') },
+    checkTool,
   );
 
   server.tool(
@@ -52,23 +32,7 @@ export async function mcp() {
         .default(DEFAULT_IGNORE_PATTERNS)
         .describe('glob patterns to ignore'),
     },
-    async ({ patterns, ignore }) => {
-      const builder = new CallToolResultBuilder();
-
-      try {
-        const results = await scan({ patterns, ignore: [...DEFAULT_IGNORE_PATTERNS, ...ignore] });
-        builder.text(
-          toList([
-            ...results.filter((r) => r.type === 'spec'),
-            ...results.filter((r) => r.type === 'tag'),
-          ]),
-        );
-      } catch (e) {
-        builder.error(PublicError.wrap(e));
-      }
-
-      return builder.build();
-    },
+    scanTool,
   );
 
   const transport = new StdioServerTransport();
@@ -76,15 +40,53 @@ export async function mcp() {
   console.error('@stringsync/spec MCP server running on stdio');
 }
 
-function toList(results: ScanResult[]): string {
-  return results.map(toListItem).join('\n');
+async function checkTool({ path }: { path: string }) {
+  const builder = new CallToolResultBuilder();
+
+  const result = await check({ path });
+  switch (result.type) {
+    case 'success':
+      builder.text(`valid @stringsync/spec: ${path}`);
+      break;
+    case 'error':
+      builder.text(`invalid @stringsync/spec: ${path}`);
+      builder.error(new PublicError(result.errors.join('\n')));
+      break;
+  }
+
+  return builder.build();
 }
 
-function toListItem(result: ScanResult): string {
-  switch (result.type) {
-    case 'spec':
-      return `- spec: ${result.name} | path: ${result.path}`;
-    case 'tag':
-      return `- tag: ${result.id} | body: ${result.body} | location: ${result.location}`;
+async function scanTool({ patterns, ignore }: { patterns: string[]; ignore: string[] }) {
+  const builder = new CallToolResultBuilder();
+
+  function toList(results: ScanResult[]): string {
+    return results.map(toListItem).join('\n');
   }
+
+  function toListItem(result: ScanResult): string {
+    switch (result.type) {
+      case 'spec':
+        return `- spec: ${result.name} | path: ${result.path}`;
+      case 'tag':
+        return `- tag: ${result.id} | body: ${result.body} | location: ${result.location}`;
+    }
+  }
+
+  try {
+    const results = await scan({
+      patterns,
+      ignore: [...DEFAULT_IGNORE_PATTERNS, ...ignore],
+    });
+    builder.text(
+      toList([
+        ...results.filter((r) => r.type === 'spec'),
+        ...results.filter((r) => r.type === 'tag'),
+      ]),
+    );
+  } catch (e) {
+    builder.error(PublicError.wrap(e));
+  }
+
+  return builder.build();
 }

--- a/actions/mcp.ts
+++ b/actions/mcp.ts
@@ -1,0 +1,3 @@
+export async function mcp() {
+  throw new Error('Unimplemented');
+}

--- a/actions/mcp.ts
+++ b/actions/mcp.ts
@@ -22,12 +22,15 @@ export async function mcp() {
     async ({ path }) => {
       const builder = new CallToolResultBuilder();
 
-      try {
-        await check({ path });
-        builder.text(`The spec is valid: ${path}`);
-      } catch (e) {
-        builder.text(`The spec is invalid: ${path}`);
-        builder.error(PublicError.wrap(e));
+      const result = await check({ path });
+      switch (result.type) {
+        case 'success':
+          builder.text(`valid @stringsync/spec: ${path}`);
+          break;
+        case 'error':
+          builder.text(`invalid @stringsync/spec: ${path}`);
+          builder.error(new PublicError(result.errors.join('\n')));
+          break;
       }
 
       return builder.build();

--- a/actions/mcp.ts
+++ b/actions/mcp.ts
@@ -5,6 +5,7 @@ import { z } from 'zod';
 import { check } from '~/actions/check';
 import { PublicError } from '~/util/errors';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { DEFAULT_IGNORE_PATTERNS, DEFAULT_PATTERNS, scan, type ScanResult } from '~/actions/scan';
 
 export async function mcp() {
   const server = new McpServer({
@@ -14,9 +15,9 @@ export async function mcp() {
 
   server.tool(
     'spec.check',
-    'Validate a spec file',
+    'validate a spec file',
     {
-      path: z.string().describe('The path to the spec file to validate'),
+      path: z.string().describe('the path to the spec file to validate'),
     },
     async ({ path }) => {
       const builder = new CallToolResultBuilder();
@@ -33,7 +34,54 @@ export async function mcp() {
     },
   );
 
+  server.tool(
+    'spec.scan',
+    'scan for specs and tags',
+    {
+      patterns: z
+        .array(z.string())
+        .optional()
+        .default(DEFAULT_PATTERNS)
+        .describe('glob patterns to scan'),
+      ignore: z
+        .array(z.string())
+        .optional()
+        .default(DEFAULT_IGNORE_PATTERNS)
+        .describe('glob patterns to ignore'),
+    },
+    async ({ patterns, ignore }) => {
+      const builder = new CallToolResultBuilder();
+
+      try {
+        const results = await scan({ patterns, ignore: [...DEFAULT_IGNORE_PATTERNS, ...ignore] });
+        builder.text(
+          toList([
+            ...results.filter((r) => r.type === 'spec'),
+            ...results.filter((r) => r.type === 'tag'),
+          ]),
+        );
+      } catch (e) {
+        builder.error(PublicError.wrap(e));
+      }
+
+      return builder.build();
+    },
+  );
+
   const transport = new StdioServerTransport();
   await server.connect(transport);
   console.error('@stringsync/spec MCP server running on stdio');
+}
+
+function toList(results: ScanResult[]): string {
+  return results.map(toListItem).join('\n');
+}
+
+function toListItem(result: ScanResult): string {
+  switch (result.type) {
+    case 'spec':
+      return `- spec: ${result.name} | path: ${result.path}`;
+    case 'tag':
+      return `- tag: ${result.id} | body: ${result.body} | location: ${result.location}`;
+  }
 }

--- a/actions/mcp.ts
+++ b/actions/mcp.ts
@@ -15,7 +15,7 @@ export async function mcp() {
 
   server.tool(
     'spec.check',
-    'validate a spec file',
+    'validate a @stringsync/spec spec file',
     {
       path: z.string().describe('the path to the spec file to validate'),
     },
@@ -39,7 +39,7 @@ export async function mcp() {
 
   server.tool(
     'spec.scan',
-    'scan for specs and tags',
+    'scan for @stringsync/spec specs and tags',
     {
       patterns: z
         .array(z.string())

--- a/actions/mcp.ts
+++ b/actions/mcp.ts
@@ -1,3 +1,39 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { name, version } from '../package.json';
+import { CallToolResultBuilder } from '~/mcp/call-tool-result-builder';
+import { z } from 'zod';
+import { check } from '~/actions/check';
+import { PublicError } from '~/util/errors';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+
 export async function mcp() {
-  throw new Error('Unimplemented');
+  const server = new McpServer({
+    name,
+    version,
+  });
+
+  server.tool(
+    'spec.check',
+    'Validate a spec file',
+    {
+      path: z.string().describe('The path to the spec file to validate'),
+    },
+    async ({ path }) => {
+      const builder = new CallToolResultBuilder();
+
+      try {
+        await check({ path });
+        builder.text(`The spec is valid: ${path}`);
+      } catch (e) {
+        builder.text(`The spec is invalid: ${path}`);
+        builder.error(PublicError.wrap(e));
+      }
+
+      return builder.build();
+    },
+  );
+
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+  console.error('@stringsync/spec MCP server running on stdio');
 }

--- a/actions/scan.ts
+++ b/actions/scan.ts
@@ -20,6 +20,7 @@ export interface TagResult {
   location: string;
 }
 
+export const DEFAULT_PATTERNS = ['**/*'];
 export const DEFAULT_IGNORE_PATTERNS = ['**/node_modules/**', '**/dist/**', '**/.git/**'];
 
 export async function scan(input: {

--- a/bun.lock
+++ b/bun.lock
@@ -4,9 +4,11 @@
     "": {
       "name": "@stringsync/intent/monorepo",
       "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.17.5",
         "chalk": "^5.6.0",
         "commander": "^14.0.0",
         "glob": "^11.0.3",
+        "zod": "3",
       },
       "devDependencies": {
         "@eslint/js": "^9.32.0",
@@ -52,6 +54,8 @@
 
     "@isaacs/cliui": ["@isaacs/cliui@8.0.2", "", { "dependencies": { "string-width": "^5.1.2", "string-width-cjs": "npm:string-width@^4.2.0", "strip-ansi": "^7.0.1", "strip-ansi-cjs": "npm:strip-ansi@^6.0.1", "wrap-ansi": "^8.1.0", "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0" } }, "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA=="],
 
+    "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.17.5", "", { "dependencies": { "ajv": "^6.12.6", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.23.8", "zod-to-json-schema": "^3.24.1" } }, "sha512-QakrKIGniGuRVfWBdMsDea/dx1PNE739QJ7gCM41s9q+qaCYTHCdsIBXQVVXry3mfWAiaM9kT22Hyz53Uw8mfg=="],
+
     "@nodelib/fs.scandir": ["@nodelib/fs.scandir@2.1.5", "", { "dependencies": { "@nodelib/fs.stat": "2.0.5", "run-parallel": "^1.1.9" } }, "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g=="],
 
     "@nodelib/fs.stat": ["@nodelib/fs.stat@2.0.5", "", {}, "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A=="],
@@ -88,6 +92,8 @@
 
     "@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.38.0", "", { "dependencies": { "@typescript-eslint/types": "8.38.0", "eslint-visitor-keys": "^4.2.1" } }, "sha512-pWrTcoFNWuwHlA9CvlfSsGWs14JxfN1TH25zM5L7o0pRLhsoZkDnTsXfQRJBEWJoV5DL0jf+Z+sxiud+K0mq1g=="],
 
+    "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
+
     "acorn": ["acorn@8.15.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg=="],
 
     "acorn-jsx": ["acorn-jsx@5.3.2", "", { "peerDependencies": { "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ=="],
@@ -106,11 +112,19 @@
 
     "binary-extensions": ["binary-extensions@2.3.0", "", {}, "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw=="],
 
+    "body-parser": ["body-parser@2.2.0", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^1.0.5", "debug": "^4.4.0", "http-errors": "^2.0.0", "iconv-lite": "^0.6.3", "on-finished": "^2.4.1", "qs": "^6.14.0", "raw-body": "^3.0.0", "type-is": "^2.0.0" } }, "sha512-02qvAaxv8tp7fBa/mw1ga98OGm+eCbqzJOKoRt70sLmfEEi+jyBYVTDGfCL/k06/4EMk/z01gCe7HoCH/f2LTg=="],
+
     "brace-expansion": ["brace-expansion@1.1.12", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg=="],
 
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
 
     "bun-types": ["bun-types@1.2.19", "", { "dependencies": { "@types/node": "*" }, "peerDependencies": { "@types/react": "^19" } }, "sha512-uAOTaZSPuYsWIXRpj7o56Let0g/wjihKCkeRqUBhlLVM/Bt+Fj9xTo+LhC1OV1XDaGkz4hNC80et5xgy+9KTHQ=="],
+
+    "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
+
+    "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
+
+    "call-bound": ["call-bound@1.0.4", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "get-intrinsic": "^1.3.0" } }, "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg=="],
 
     "callsites": ["callsites@3.1.0", "", {}, "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="],
 
@@ -132,6 +146,16 @@
 
     "concat-map": ["concat-map@0.0.1", "", {}, "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="],
 
+    "content-disposition": ["content-disposition@1.0.0", "", { "dependencies": { "safe-buffer": "5.2.1" } }, "sha512-Au9nRL8VNUut/XSzbQA38+M78dzP4D+eqg3gfJHMIHHYa3bg067xj1KxMUWj+VULbiZMowKngFFbKczUrNJ1mg=="],
+
+    "content-type": ["content-type@1.0.5", "", {}, "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="],
+
+    "cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
+
+    "cookie-signature": ["cookie-signature@1.2.2", "", {}, "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg=="],
+
+    "cors": ["cors@2.8.5", "", { "dependencies": { "object-assign": "^4", "vary": "^1" } }, "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g=="],
+
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
 
     "csstype": ["csstype@3.1.3", "", {}, "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="],
@@ -142,9 +166,25 @@
 
     "deep-is": ["deep-is@0.1.4", "", {}, "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="],
 
+    "depd": ["depd@2.0.0", "", {}, "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="],
+
+    "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
+
     "eastasianwidth": ["eastasianwidth@0.2.0", "", {}, "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="],
 
+    "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
+
     "emoji-regex": ["emoji-regex@7.0.3", "", {}, "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA=="],
+
+    "encodeurl": ["encodeurl@2.0.0", "", {}, "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="],
+
+    "es-define-property": ["es-define-property@1.0.1", "", {}, "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="],
+
+    "es-errors": ["es-errors@1.3.0", "", {}, "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="],
+
+    "es-object-atoms": ["es-object-atoms@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA=="],
+
+    "escape-html": ["escape-html@1.0.3", "", {}, "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="],
 
     "escape-string-regexp": ["escape-string-regexp@4.0.0", "", {}, "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="],
 
@@ -164,6 +204,16 @@
 
     "esutils": ["esutils@2.0.3", "", {}, "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="],
 
+    "etag": ["etag@1.8.1", "", {}, "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="],
+
+    "eventsource": ["eventsource@3.0.7", "", { "dependencies": { "eventsource-parser": "^3.0.1" } }, "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA=="],
+
+    "eventsource-parser": ["eventsource-parser@3.0.6", "", {}, "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg=="],
+
+    "express": ["express@5.1.0", "", { "dependencies": { "accepts": "^2.0.0", "body-parser": "^2.2.0", "content-disposition": "^1.0.0", "content-type": "^1.0.5", "cookie": "^0.7.1", "cookie-signature": "^1.2.1", "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "finalhandler": "^2.1.0", "fresh": "^2.0.0", "http-errors": "^2.0.0", "merge-descriptors": "^2.0.0", "mime-types": "^3.0.0", "on-finished": "^2.4.1", "once": "^1.4.0", "parseurl": "^1.3.3", "proxy-addr": "^2.0.7", "qs": "^6.14.0", "range-parser": "^1.2.1", "router": "^2.2.0", "send": "^1.1.0", "serve-static": "^2.2.0", "statuses": "^2.0.1", "type-is": "^2.0.1", "vary": "^1.1.2" } }, "sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA=="],
+
+    "express-rate-limit": ["express-rate-limit@7.5.1", "", { "peerDependencies": { "express": ">= 4.11" } }, "sha512-7iN8iPMDzOMHPUYllBEsQdWVB6fPDMPqwjBaFrgr4Jgr/+okjvzAy+UHlYYL/Vs0OsOrMkwS6PJDkFlJwoxUnw=="],
+
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
 
     "fast-glob": ["fast-glob@3.3.3", "", { "dependencies": { "@nodelib/fs.stat": "^2.0.2", "@nodelib/fs.walk": "^1.2.3", "glob-parent": "^5.1.2", "merge2": "^1.3.0", "micromatch": "^4.0.8" } }, "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg=="],
@@ -178,6 +228,8 @@
 
     "fill-range": ["fill-range@7.1.1", "", { "dependencies": { "to-regex-range": "^5.0.1" } }, "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg=="],
 
+    "finalhandler": ["finalhandler@2.1.0", "", { "dependencies": { "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "on-finished": "^2.4.1", "parseurl": "^1.3.3", "statuses": "^2.0.1" } }, "sha512-/t88Ty3d5JWQbWYgaOGCCYfXRwV1+be02WqYYlL6h0lEiUAMPM8o8qKGO01YIkOHzka2up08wvgYD0mDiI+q3Q=="],
+
     "find-up": ["find-up@5.0.0", "", { "dependencies": { "locate-path": "^6.0.0", "path-exists": "^4.0.0" } }, "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng=="],
 
     "flat-cache": ["flat-cache@4.0.1", "", { "dependencies": { "flatted": "^3.2.9", "keyv": "^4.5.4" } }, "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw=="],
@@ -186,9 +238,19 @@
 
     "foreground-child": ["foreground-child@3.3.1", "", { "dependencies": { "cross-spawn": "^7.0.6", "signal-exit": "^4.0.1" } }, "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw=="],
 
+    "forwarded": ["forwarded@0.2.0", "", {}, "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="],
+
+    "fresh": ["fresh@2.0.0", "", {}, "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A=="],
+
     "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
+    "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
+
     "get-caller-file": ["get-caller-file@2.0.5", "", {}, "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="],
+
+    "get-intrinsic": ["get-intrinsic@1.3.0", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "function-bind": "^1.1.2", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "math-intrinsics": "^1.1.0" } }, "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ=="],
+
+    "get-proto": ["get-proto@1.0.1", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-object-atoms": "^1.0.0" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
 
     "glob": ["glob@11.0.3", "", { "dependencies": { "foreground-child": "^3.3.1", "jackspeak": "^4.1.1", "minimatch": "^10.0.3", "minipass": "^7.1.2", "package-json-from-dist": "^1.0.0", "path-scurry": "^2.0.0" }, "bin": { "glob": "dist/esm/bin.mjs" } }, "sha512-2Nim7dha1KVkaiF4q6Dj+ngPPMdfvLJEOpZk/jKiUAkqKebpGAWQXAq9z1xu9HKu5lWfqw/FASuccEjyznjPaA=="],
 
@@ -196,15 +258,29 @@
 
     "globals": ["globals@14.0.0", "", {}, "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ=="],
 
+    "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
+
     "graphemer": ["graphemer@1.4.0", "", {}, "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag=="],
 
     "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
+
+    "has-symbols": ["has-symbols@1.1.0", "", {}, "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="],
+
+    "hasown": ["hasown@2.0.2", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ=="],
+
+    "http-errors": ["http-errors@2.0.0", "", { "dependencies": { "depd": "2.0.0", "inherits": "2.0.4", "setprototypeof": "1.2.0", "statuses": "2.0.1", "toidentifier": "1.0.1" } }, "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ=="],
+
+    "iconv-lite": ["iconv-lite@0.7.0", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-cf6L2Ds3h57VVmkZe+Pn+5APsT7FpqJtEhhieDCvrE2MK5Qk9MyffgQyuxQTm6BChfeZNtcOLHp9IcWRVcIcBQ=="],
 
     "ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
 
     "import-fresh": ["import-fresh@3.3.1", "", { "dependencies": { "parent-module": "^1.0.0", "resolve-from": "^4.0.0" } }, "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ=="],
 
     "imurmurhash": ["imurmurhash@0.1.4", "", {}, "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA=="],
+
+    "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
+
+    "ipaddr.js": ["ipaddr.js@1.9.1", "", {}, "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="],
 
     "is-binary-path": ["is-binary-path@2.1.0", "", { "dependencies": { "binary-extensions": "^2.0.0" } }, "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw=="],
 
@@ -215,6 +291,8 @@
     "is-glob": ["is-glob@4.0.3", "", { "dependencies": { "is-extglob": "^2.1.1" } }, "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg=="],
 
     "is-number": ["is-number@7.0.0", "", {}, "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="],
+
+    "is-promise": ["is-promise@4.0.0", "", {}, "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="],
 
     "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
 
@@ -244,9 +322,19 @@
 
     "lru-cache": ["lru-cache@11.2.1", "", {}, "sha512-r8LA6i4LP4EeWOhqBaZZjDWwehd1xUJPCJd9Sv300H0ZmcUER4+JPh7bqqZeqs1o5pgtgvXm+d9UGrB5zZGDiQ=="],
 
+    "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
+
+    "media-typer": ["media-typer@1.1.0", "", {}, "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw=="],
+
+    "merge-descriptors": ["merge-descriptors@2.0.0", "", {}, "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g=="],
+
     "merge2": ["merge2@1.4.1", "", {}, "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="],
 
     "micromatch": ["micromatch@4.0.8", "", { "dependencies": { "braces": "^3.0.3", "picomatch": "^2.3.1" } }, "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA=="],
+
+    "mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
+
+    "mime-types": ["mime-types@3.0.1", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA=="],
 
     "minimatch": ["minimatch@3.1.2", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw=="],
 
@@ -256,7 +344,17 @@
 
     "natural-compare": ["natural-compare@1.4.0", "", {}, "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="],
 
+    "negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
+
     "normalize-path": ["normalize-path@3.0.0", "", {}, "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="],
+
+    "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
+
+    "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
+
+    "on-finished": ["on-finished@2.4.1", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="],
+
+    "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
 
     "optionator": ["optionator@0.9.4", "", { "dependencies": { "deep-is": "^0.1.3", "fast-levenshtein": "^2.0.6", "levn": "^0.4.1", "prelude-ls": "^1.2.1", "type-check": "^0.4.0", "word-wrap": "^1.2.5" } }, "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g=="],
 
@@ -270,21 +368,35 @@
 
     "parent-module": ["parent-module@1.0.1", "", { "dependencies": { "callsites": "^3.0.0" } }, "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g=="],
 
+    "parseurl": ["parseurl@1.3.3", "", {}, "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="],
+
     "path-exists": ["path-exists@4.0.0", "", {}, "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="],
 
     "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
 
     "path-scurry": ["path-scurry@2.0.0", "", { "dependencies": { "lru-cache": "^11.0.0", "minipass": "^7.1.2" } }, "sha512-ypGJsmGtdXUOeM5u93TyeIEfEhM6s+ljAhrk5vAvSx8uyY/02OvrZnA0YNGUrPXfpJMgI1ODd3nwz8Npx4O4cg=="],
 
+    "path-to-regexp": ["path-to-regexp@8.3.0", "", {}, "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA=="],
+
     "picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
+
+    "pkce-challenge": ["pkce-challenge@5.0.0", "", {}, "sha512-ueGLflrrnvwB3xuo/uGob5pd5FN7l0MsLf0Z87o/UQmRtwjvfylfc9MurIxRAWywCYTgrvpXBcqjV4OfCYGCIQ=="],
 
     "prelude-ls": ["prelude-ls@1.2.1", "", {}, "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="],
 
     "prettier": ["prettier@3.6.2", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ=="],
 
+    "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
+
     "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
 
+    "qs": ["qs@6.14.0", "", { "dependencies": { "side-channel": "^1.1.0" } }, "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w=="],
+
     "queue-microtask": ["queue-microtask@1.2.3", "", {}, "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="],
+
+    "range-parser": ["range-parser@1.2.1", "", {}, "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="],
+
+    "raw-body": ["raw-body@3.0.1", "", { "dependencies": { "bytes": "3.1.2", "http-errors": "2.0.0", "iconv-lite": "0.7.0", "unpipe": "1.0.0" } }, "sha512-9G8cA+tuMS75+6G/TzW8OtLzmBDMo8p1JRxN5AZ+LAp8uxGA8V8GZm4GQ4/N5QNQEnLmg6SS7wyuSmbKepiKqA=="],
 
     "readdirp": ["readdirp@3.6.0", "", { "dependencies": { "picomatch": "^2.2.1" } }, "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA=="],
 
@@ -296,17 +408,39 @@
 
     "reusify": ["reusify@1.1.0", "", {}, "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw=="],
 
+    "router": ["router@2.2.0", "", { "dependencies": { "debug": "^4.4.0", "depd": "^2.0.0", "is-promise": "^4.0.0", "parseurl": "^1.3.3", "path-to-regexp": "^8.0.0" } }, "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ=="],
+
     "run-parallel": ["run-parallel@1.2.0", "", { "dependencies": { "queue-microtask": "^1.2.2" } }, "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA=="],
+
+    "safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
+
+    "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
 
     "semver": ["semver@7.7.2", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA=="],
 
+    "send": ["send@1.2.0", "", { "dependencies": { "debug": "^4.3.5", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "fresh": "^2.0.0", "http-errors": "^2.0.0", "mime-types": "^3.0.1", "ms": "^2.1.3", "on-finished": "^2.4.1", "range-parser": "^1.2.1", "statuses": "^2.0.1" } }, "sha512-uaW0WwXKpL9blXE2o0bRhoL2EGXIrZxQ2ZQ4mgcfoBxdFmQold+qWsD2jLrfZ0trjKL6vOw0j//eAwcALFjKSw=="],
+
+    "serve-static": ["serve-static@2.2.0", "", { "dependencies": { "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "parseurl": "^1.3.3", "send": "^1.2.0" } }, "sha512-61g9pCh0Vnh7IutZjtLGGpTA355+OPn2TyDv/6ivP2h/AdAVX9azsoxmg2/M6nZeQZNYBEwIcsne1mJd9oQItQ=="],
+
     "set-blocking": ["set-blocking@2.0.0", "", {}, "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw=="],
+
+    "setprototypeof": ["setprototypeof@1.2.0", "", {}, "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="],
 
     "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
 
     "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
 
+    "side-channel": ["side-channel@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.3", "side-channel-list": "^1.0.0", "side-channel-map": "^1.0.1", "side-channel-weakmap": "^1.0.2" } }, "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw=="],
+
+    "side-channel-list": ["side-channel-list@1.0.0", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.3" } }, "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA=="],
+
+    "side-channel-map": ["side-channel-map@1.0.1", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3" } }, "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA=="],
+
+    "side-channel-weakmap": ["side-channel-weakmap@1.0.2", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3", "side-channel-map": "^1.0.1" } }, "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A=="],
+
     "signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
+
+    "statuses": ["statuses@2.0.1", "", {}, "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ=="],
 
     "string-width": ["string-width@3.1.0", "", { "dependencies": { "emoji-regex": "^7.0.1", "is-fullwidth-code-point": "^2.0.0", "strip-ansi": "^5.1.0" } }, "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w=="],
 
@@ -322,9 +456,13 @@
 
     "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
 
+    "toidentifier": ["toidentifier@1.0.1", "", {}, "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="],
+
     "ts-api-utils": ["ts-api-utils@2.1.0", "", { "peerDependencies": { "typescript": ">=4.8.4" } }, "sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ=="],
 
     "type-check": ["type-check@0.4.0", "", { "dependencies": { "prelude-ls": "^1.2.1" } }, "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew=="],
+
+    "type-is": ["type-is@2.0.1", "", { "dependencies": { "content-type": "^1.0.5", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw=="],
 
     "typescript": ["typescript@5.9.2", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A=="],
 
@@ -332,7 +470,11 @@
 
     "undici-types": ["undici-types@7.8.0", "", {}, "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw=="],
 
+    "unpipe": ["unpipe@1.0.0", "", {}, "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="],
+
     "uri-js": ["uri-js@4.4.1", "", { "dependencies": { "punycode": "^2.1.0" } }, "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg=="],
+
+    "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
 
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 
@@ -344,6 +486,8 @@
 
     "wrap-ansi-cjs": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
 
+    "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
+
     "y18n": ["y18n@4.0.3", "", {}, "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ=="],
 
     "yargs": ["yargs@13.3.2", "", { "dependencies": { "cliui": "^5.0.0", "find-up": "^3.0.0", "get-caller-file": "^2.0.1", "require-directory": "^2.1.1", "require-main-filename": "^2.0.0", "set-blocking": "^2.0.0", "string-width": "^3.0.0", "which-module": "^2.0.0", "y18n": "^4.0.0", "yargs-parser": "^13.1.2" } }, "sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw=="],
@@ -351,6 +495,10 @@
     "yargs-parser": ["yargs-parser@13.1.2", "", { "dependencies": { "camelcase": "^5.0.0", "decamelize": "^1.2.0" } }, "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg=="],
 
     "yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
+
+    "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
+    "zod-to-json-schema": ["zod-to-json-schema@3.24.6", "", { "peerDependencies": { "zod": "^3.24.1" } }, "sha512-h/z3PKvcTcTetyjl1fkj79MHNEjm+HpD6NXheWjzOekY7kV+lwDYnHw+ivHkijnCSMz1yJaWBD9vu/Fcmk+vEg=="],
 
     "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
 
@@ -365,6 +513,8 @@
     "@typescript-eslint/eslint-plugin/ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
 
     "@typescript-eslint/typescript-estree/minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
+
+    "body-parser/iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
 
     "chokidar/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 

--- a/index.ts
+++ b/index.ts
@@ -5,6 +5,7 @@ import { check } from '~/actions/check';
 import { DEFAULT_IGNORE_PATTERNS, scan } from '~/actions/scan';
 import chalk from 'chalk';
 import { Stopwatch } from '~/util/stopwatch';
+import { mcp } from '~/actions/mcp';
 
 function log(...messages: string[]) {
   console.log(messages.filter(Boolean).join(' '));
@@ -30,6 +31,13 @@ program
         log(`${result.errors.join('\n')}`);
         break;
     }
+  });
+
+program
+  .command('mcp')
+  .description('run an model context protocol (MCP) server')
+  .action(async () => {
+    await mcp();
   });
 
 program

--- a/index.ts
+++ b/index.ts
@@ -37,7 +37,12 @@ program
   .command('mcp')
   .description('run an model context protocol (MCP) server')
   .action(async () => {
-    await mcp();
+    try {
+      await mcp();
+    } catch (e) {
+      console.error(chalk.red('Fatal error:'), e instanceof Error ? e.message : e);
+      process.exit(1);
+    }
   });
 
 program

--- a/index.ts
+++ b/index.ts
@@ -2,7 +2,7 @@
 import { program } from 'commander';
 import { name, description, version } from './package.json';
 import { check } from '~/actions/check';
-import { DEFAULT_IGNORE_PATTERNS, scan } from '~/actions/scan';
+import { DEFAULT_IGNORE_PATTERNS, DEFAULT_PATTERNS, scan } from '~/actions/scan';
 import chalk from 'chalk';
 import { Stopwatch } from '~/util/stopwatch';
 import { mcp } from '~/actions/mcp';
@@ -47,8 +47,8 @@ program
 
 program
   .command('scan')
-  .description('scans a directory for specs and tags')
-  .argument('[patterns...]', 'glob patterns to scan', ['**/*'])
+  .description('scan for specs and tags')
+  .argument('[patterns...]', 'glob patterns to scan', DEFAULT_PATTERNS)
   .option('--ignore [patterns...]', 'glob patterns to ignore', [])
   .action(async (patterns: string[], options: { ignore: string[] }) => {
     const stopwatch = Stopwatch.start();

--- a/index.ts
+++ b/index.ts
@@ -6,6 +6,7 @@ import { DEFAULT_IGNORE_PATTERNS, DEFAULT_PATTERNS, scan } from '~/actions/scan'
 import chalk from 'chalk';
 import { Stopwatch } from '~/util/stopwatch';
 import { mcp } from '~/actions/mcp';
+import { StringSyncError } from '~/util/errors';
 
 function log(...messages: string[]) {
   console.log(messages.filter(Boolean).join(' '));
@@ -40,7 +41,7 @@ program
     try {
       await mcp();
     } catch (e) {
-      console.error(chalk.red('Fatal error:'), e instanceof Error ? e.message : e);
+      console.error(chalk.red('Fatal error:'), StringSyncError.wrap(e).message);
       process.exit(1);
     }
   });

--- a/mcp/call-tool-result-builder.ts
+++ b/mcp/call-tool-result-builder.ts
@@ -1,0 +1,28 @@
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import { StringSyncError } from '~/util/errors';
+
+export class CallToolResultBuilder {
+  private content = new Array<CallToolResult['content'][number]>();
+
+  text(text: string): this {
+    this.content.push({ type: 'text', text });
+    return this;
+  }
+
+  error(error: StringSyncError): this {
+    let text = '';
+    if (error.isPublic) {
+      text = error.message;
+    } else {
+      text =
+        'Something went wrong, but the error details were omitted for security reasons. ' +
+        'Check the error logs if you have access.';
+    }
+    this.content.push({ type: 'text', isError: true, text });
+    return this;
+  }
+
+  build(): CallToolResult {
+    return { content: [...this.content] };
+  }
+}

--- a/package.json
+++ b/package.json
@@ -30,8 +30,10 @@
     "typescript-eslint": "^8.38.0"
   },
   "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.17.5",
     "chalk": "^5.6.0",
     "commander": "^14.0.0",
-    "glob": "^11.0.3"
+    "glob": "^11.0.3",
+    "zod": "3"
   }
 }

--- a/tags/parse.test.ts
+++ b/tags/parse.test.ts
@@ -302,6 +302,23 @@ describe('parse', () => {
   });
 
   describe('styles', () => {
+    it('any text', () => {
+      const file = new File(
+        'test.txt',
+        `
+        spec(foo.bar): baz
+        `,
+      );
+
+      const tags = parse('spec', file, [Style.Any]);
+
+      expect(tags).toHaveLength(1);
+      expect(tags[0].name).toBe('spec');
+      expect(tags[0].id).toBe('foo.bar');
+      expect(tags[0].body).toBe('baz');
+      expect(tags[0].location).toBe('test.md:2:9');
+    });
+
     it('//', () => {
       const file = new File(
         'test.ts',

--- a/tags/parse.test.ts
+++ b/tags/parse.test.ts
@@ -316,7 +316,7 @@ describe('parse', () => {
       expect(tags[0].name).toBe('spec');
       expect(tags[0].id).toBe('foo.bar');
       expect(tags[0].body).toBe('baz');
-      expect(tags[0].location).toBe('test.md:2:9');
+      expect(tags[0].location).toBe('test.txt:2:9');
     });
 
     it('//', () => {
@@ -603,6 +603,59 @@ describe('parse', () => {
       expect(tags[0].id).toBe('foo.bar');
       expect(tags[0].body).toBe('baz');
       expect(tags[0].location).toBe('test.html:3:9');
+    });
+
+    it(';', () => {
+      const file = new File(
+        'test.ini',
+        `
+        ; spec(foo.bar): baz
+        `,
+      );
+
+      const tags = parse('spec', file, [Style.Semicolon]);
+
+      expect(tags).toHaveLength(1);
+      expect(tags[0].name).toBe('spec');
+      expect(tags[0].id).toBe('foo.bar');
+      expect(tags[0].body).toBe('baz');
+      expect(tags[0].location).toBe('test.ini:2:11');
+    });
+
+    it('--[[ ]] (single line)', () => {
+      const file = new File(
+        'test.lua',
+        `
+        --[[spec(foo.bar): baz]]
+        `,
+      );
+
+      const tags = parse('spec', file, [Style.LuaBlock]);
+
+      expect(tags).toHaveLength(1);
+      expect(tags[0].name).toBe('spec');
+      expect(tags[0].id).toBe('foo.bar');
+      expect(tags[0].body).toBe('baz');
+      expect(tags[0].location).toBe('test.lua:2:13');
+    });
+
+    it('--[[ ]] (multi line)', () => {
+      const file = new File(
+        'test.lua',
+        `
+        --[[
+        spec(foo.bar): baz
+        ]]
+        `,
+      );
+
+      const tags = parse('spec', file, [Style.LuaBlock]);
+
+      expect(tags).toHaveLength(1);
+      expect(tags[0].name).toBe('spec');
+      expect(tags[0].id).toBe('foo.bar');
+      expect(tags[0].body).toBe('baz');
+      expect(tags[0].location).toBe('test.lua:3:9');
     });
   });
 });

--- a/tags/parse.ts
+++ b/tags/parse.ts
@@ -26,7 +26,7 @@ export function parse(tagName: string, file: File, styles?: Style[]): Tag[] {
 
       // Skip if we've already processed this position
       if (processedPositions.has(startIndex)) {
-        index = startIndex + style.start.length;
+        index = startIndex + Math.max(style.start.length, 1);
         continue;
       }
 

--- a/tags/style.ts
+++ b/tags/style.ts
@@ -16,6 +16,7 @@ export class Style {
     return new Style('block', start, middle, end);
   }
 
+  static Any = Style.single('');
   static DoubleSlash = Style.single('//');
   static SlashSingleStarBlock = Style.block('/*', '*', '*/');
   static SlashDoubleStarBlock = Style.block('/**', '*', '*/');
@@ -43,14 +44,13 @@ export class Style {
           Style.DoubleSlash,
           Style.SlashDoubleStarBlock,
           Style.SlashSingleStarBlock,
-          Style.SlashDoubleStarBlock,
           Style.TripleSlash,
         ];
       case 'xml':
       case 'html':
         return [Style.AngleBracketBlock];
       default:
-        return [];
+        return [Style.Any];
     }
   }
 }

--- a/tags/style.ts
+++ b/tags/style.ts
@@ -26,19 +26,63 @@ export class Style {
   static TripleSingleQuote = Style.block(`'''`, '', `'''`);
   static TripleSlash = Style.single('///');
   static AngleBracketBlock = Style.block('<!--', '', '-->');
+  static Semicolon = Style.single(';');
+  static LuaBlock = Style.block('--[[', '', ']]');
 
   static for(file: File): Style[] {
     switch (file.getExtension()) {
       case 'js':
       case 'ts':
+      case 'jsx':
+      case 'tsx':
         return [Style.DoubleSlash, Style.SlashDoubleStarBlock, Style.SlashSingleStarBlock];
+      case 'java':
+      case 'c':
+      case 'cpp':
+      case 'cc':
+      case 'cxx':
+      case 'h':
+      case 'hpp':
+      case 'go':
+      case 'rs':
+      case 'swift':
+      case 'kt':
+      case 'scala':
+      case 'dart':
+        return [Style.DoubleSlash, Style.SlashDoubleStarBlock, Style.SlashSingleStarBlock];
+      case 'php':
+        return [
+          Style.DoubleSlash,
+          Style.SlashDoubleStarBlock,
+          Style.SlashSingleStarBlock,
+          Style.Hash,
+        ];
+      case 'css':
+      case 'scss':
+      case 'sass':
+      case 'less':
+        return [Style.SlashDoubleStarBlock, Style.SlashSingleStarBlock];
       case 'sql':
         return [Style.DoubleDash];
+      case 'lua':
+        return [Style.DoubleDash, Style.LuaBlock];
       case 'ex':
       case 'exs':
         return [Style.Hash, Style.TripleDoubleQuote];
       case 'py':
         return [Style.Hash, Style.TripleDoubleQuote, Style.TripleSingleQuote];
+      case 'rb':
+      case 'sh':
+      case 'bash':
+      case 'zsh':
+      case 'fish':
+      case 'yaml':
+      case 'yml':
+      case 'toml':
+      case 'r':
+      case 'pl':
+      case 'pm':
+        return [Style.Hash];
       case 'cs':
         return [
           Style.DoubleSlash,
@@ -48,7 +92,14 @@ export class Style {
         ];
       case 'xml':
       case 'html':
+      case 'vue':
+      case 'svelte':
+      case 'md':
+      case 'markdown':
         return [Style.AngleBracketBlock];
+      case 'ini':
+      case 'cfg':
+        return [Style.Semicolon, Style.Hash];
       default:
         return [Style.Any];
     }

--- a/util/errors.ts
+++ b/util/errors.ts
@@ -1,0 +1,21 @@
+export class StringSyncError extends Error {
+  static wrap(value: unknown): StringSyncError {
+    if (value instanceof this) {
+      return value;
+    } else if (value instanceof Error) {
+      return new this(value.message);
+    } else if (typeof value === 'string') {
+      return new this(value);
+    } else {
+      return new this('An unknown error occurred');
+    }
+  }
+
+  // By default, errors are not public to reduce the risk of leaking sensitive information to an
+  // client (LLM).
+  public readonly isPublic: boolean = false;
+}
+
+export class PublicError extends StringSyncError {
+  public readonly isPublic = true;
+}


### PR DESCRIPTION
This PR adds more supported comment styles from popular languages. It will fallback to just scanning for `spec(id): body` if the language is not officially supported.

This PR also adds basic MCP support with `spec.check` and `spec.scan` tools.