### PR TITLE
Add spec.describe MCP prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,12 +64,13 @@ To run the @stringsync/spec MCP server, the command is:
 bunx @stringsync/spec mcp
 ```
 
-Read your agent's documentation to run the MCP server. For example, Claude's configuration will look like this:
+Read your agent's documentation to run the MCP server. For example, Cline's configuration will look like this:
 
 ```json
 {
   "mcpServers": {
     "@stringsync/spec": {
+      "type": "stdio",
       "command": "bunx",
       "args": ["-y", "@stringsync/spec", "mcp"]
     }
@@ -79,6 +80,9 @@ Read your agent's documentation to run the MCP server. For example, Claude's con
 
 > [!NOTE]  
 > The `-y` flag skips confirmation to download packages.
+
+> [!NOTE]  
+> Claude Desktop must use `npx`, since the paths aren't configurable.
 
 To run the MCP inspector, run:
 

--- a/util/mcp/get-prompt-result-builder.ts
+++ b/util/mcp/get-prompt-result-builder.ts
@@ -1,0 +1,55 @@
+import type { GetPromptResult } from '@modelcontextprotocol/sdk/types.js';
+
+export class GetPromptResultBuilder {
+  private messages = new Array<GetPromptResult['messages'][number]>();
+
+  constructor(private description: string) {}
+
+  user() {
+    return new GetPromptResultBuilder.MessageAppender(this, 'user');
+  }
+
+  assistant() {
+    return new GetPromptResultBuilder.MessageAppender(this, 'assistant');
+  }
+
+  build(): GetPromptResult {
+    return {
+      description: this.description,
+      messages: [...this.messages],
+    };
+  }
+
+  private static MessageAppender = class {
+    constructor(
+      private getPromptResultBuilder: GetPromptResultBuilder,
+      private role: GetPromptResult['messages'][number]['role'],
+    ) {}
+
+    text(text: string): GetPromptResultBuilder {
+      this.getPromptResultBuilder.messages.push({
+        role: this.role,
+        content: {
+          type: 'text',
+          text,
+        },
+      });
+      return this.getPromptResultBuilder;
+    }
+
+    resource(uri: string, text: string, mimeType: string): GetPromptResultBuilder {
+      this.getPromptResultBuilder.messages.push({
+        role: this.role,
+        content: {
+          type: 'resource',
+          resource: {
+            uri,
+            text,
+            mimeType,
+          },
+        },
+      });
+      return this.getPromptResultBuilder;
+    }
+  };
+}

--- a/util/mcp/get-prompt-result-builder.ts
+++ b/util/mcp/get-prompt-result-builder.ts
@@ -3,19 +3,16 @@ import type { GetPromptResult } from '@modelcontextprotocol/sdk/types.js';
 export class GetPromptResultBuilder {
   private messages = new Array<GetPromptResult['messages'][number]>();
 
-  constructor(private description: string) {}
-
-  user() {
+  get user() {
     return new GetPromptResultBuilder.MessageAppender(this, 'user');
   }
 
-  assistant() {
+  get assistant() {
     return new GetPromptResultBuilder.MessageAppender(this, 'assistant');
   }
 
   build(): GetPromptResult {
     return {
-      description: this.description,
       messages: [...this.messages],
     };
   }
@@ -26,7 +23,7 @@ export class GetPromptResultBuilder {
       private role: GetPromptResult['messages'][number]['role'],
     ) {}
 
-    text(text: string): GetPromptResultBuilder {
+    text(text: string) {
       this.getPromptResultBuilder.messages.push({
         role: this.role,
         content: {
@@ -37,7 +34,7 @@ export class GetPromptResultBuilder {
       return this.getPromptResultBuilder;
     }
 
-    resource(uri: string, text: string, mimeType: string): GetPromptResultBuilder {
+    resource(uri: string, text: string, mimeType: string) {
       this.getPromptResultBuilder.messages.push({
         role: this.role,
         content: {


### PR DESCRIPTION
This PR adds the spec.describe MCP prompt to test out MCP prompt capabilities for more reliable tool calling.